### PR TITLE
Prevent Windows line-ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Line Endings Help for Windows Users
+#
+
+# Handle line endings
+*text-false
+
+# Never modify line endings in our bash scripts
+*.sh -cflf
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.gitattributes text
+.gitignore text
+*.md text


### PR DESCRIPTION
Adds .gitattributes file to help Windows users avoid auto line-ending conversions.